### PR TITLE
Add an account_id property to the profile class

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,5 +10,5 @@ Fixes https://github.com/bachya/py17track/issues/<ISSUE ID>
 - [ ] Update `README.md` with any new documentation.
 - [ ] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
 - [ ] Ensure you have no linting errors: `make lint` (after running `make init`)
-- [ ] Ensure you have no typed your code correctly: `make typing` (after running `make init`)
+- [ ] Ensure you have typed your code correctly: `make typing` (after running `make init`)
 - [ ] Add yourself to `AUTHORS.md`.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ async def main() -> None:
       # Login to 17track.net:
       await client.profile.login('<EMAIL>', '<PASSWORD>')
 
+      # Get the account ID:
+      client.profile.account_id
+      # >>> 1234567890987654321
+
       # Get a summary of the user's packages:
       summary = await client.profile.summary()
       # >>> {'In Transit': 3, 'Expired': 3, ... }

--- a/example.py
+++ b/example.py
@@ -12,10 +12,11 @@ async def main() -> None:
     async with ClientSession() as websession:
         try:
             client = Client(websession)
-            # await client.profile.login('<EMAIL>', '<PASSWORD>')
-            await client.profile.login(
-                'tielemans.jorim@gmail.com', '1arwdrKJx@rF#3Qq')
+            await client.profile.login('<EMAIL>', '<PASSWORD>')
 
+            print('Account ID: {0}'.format(client.profile.account_id))
+
+            print()
             print('Getting account summary...')
             summary = await client.profile.summary()
             print(summary)

--- a/py17track/profile.py
+++ b/py17track/profile.py
@@ -14,6 +14,7 @@ class Profile:
     def __init__(self, request: Callable[..., Coroutine]) -> None:
         """Initialize."""
         self._request = request
+        self.account_id = None
 
     async def login(self, email: str, password: str) -> bool:
         """Login to the profile."""
@@ -33,6 +34,8 @@ class Profile:
 
         if login_resp.get('Code') != 0:
             return False
+
+        self.account_id = login_resp['Json']['gid']
 
         return True
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the user's 17track.net account ID as a property of the `Profile` class.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
