### PR TITLE
Allow Package objects to be hashable

### DIFF
--- a/py17track/package.py
+++ b/py17track/package.py
@@ -251,7 +251,7 @@ PACKAGE_TYPE_MAP = {
 }
 
 
-@attr.s  # pylint: disable=too-few-public-methods
+@attr.s(cmp=False)  # pylint: disable=too-few-public-methods
 class Package:
     """Define a package object."""
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR alters `Package` objects to be hashable (which allows them to be compared in sets, etc.).

**Does this fix a specific issue?**

N.A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
