### PR TITLE
Fix a bug in how Packages are hashed

### DIFF
--- a/py17track/package.py
+++ b/py17track/package.py
@@ -251,7 +251,7 @@ PACKAGE_TYPE_MAP = {
 }
 
 
-@attr.s(cmp=False)  # pylint: disable=too-few-public-methods
+@attr.s(frozen=True)  # pylint: disable=too-few-public-methods
 class Package:
     """Define a package object."""
 
@@ -268,7 +268,11 @@ class Package:
     # pylint: disable=attribute-defined-outside-init
     def __attrs_post_init__(self):
         """Do some post-init processing."""
-        self.destination_country = COUNTRY_MAP[self.destination_country]
-        self.origin_country = COUNTRY_MAP[self.origin_country]
-        self.package_type = PACKAGE_TYPE_MAP[self.package_type]
-        self.status = PACKAGE_STATUS_MAP[self.status]
+        object.__setattr__(
+            self, 'destination_country', COUNTRY_MAP[self.destination_country])
+        object.__setattr__(
+            self, 'origin_country', COUNTRY_MAP[self.origin_country])
+        object.__setattr__(
+            self, 'package_type', PACKAGE_TYPE_MAP[self.package_type])
+        object.__setattr__(
+            self, 'status', PACKAGE_STATUS_MAP[self.status])


### PR DESCRIPTION
**Describe what the PR does:**

The `Packages` class was not correctly hashing itself, meaning that multiple `Package` objects could not be compared to one another. This PR fixes that issue (by applying [the suggestion provided by `attrs`](http://www.attrs.org/en/stable/init.html#post-init-hook)).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)