### PR TITLE
Switch to f-strings (and remove support for Python 3.5.3)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,20 +4,15 @@ verify_ssl = true
 
 [dev-packages]
 "flake8" = "*"
-Jinja2 = ">=2.10.1"
 aresponses = "*"
-astroid = "<2.2.0"
-detox = "*"
 mypy = "*"
 pre-commit = "*"
 pydocstyle = "*"
-pylint = "<2.3.0"
+pylint = "*"
 pytest-aiohttp = "*"
 pytest-cov = "*"
 tox = "*"
 twine = "*"
-typed-ast = "<1.4.0,>=1.3.1"
-urllib3 = ">=1.24.2"
 
 [packages]
 aiohttp = "*"

--- a/README.md
+++ b/README.md
@@ -19,12 +19,8 @@ API may stop working at any moment.
 
 `py17track` is currently supported on:
 
-* Python 3.5
 * Python 3.6
 * Python 3.7
-
-However, running the test suite currently requires Python 3.6 or higher; tests
-run on Python 3.5 will fail.
 
 # Installation
 

--- a/py17track/client.py
+++ b/py17track/client.py
@@ -27,7 +27,7 @@ class Client:  # pylint: disable=too-few-public-methods
         *,
         headers: dict = None,
         params: dict = None,
-        json: dict = None
+        json: dict = None,
     ) -> dict:
         """Make a request against the RainMachine device."""
         if not headers:
@@ -41,4 +41,4 @@ class Client:  # pylint: disable=too-few-public-methods
                 data = await resp.json(content_type=None)
                 return data
         except ClientError as err:
-            raise RequestError("Error requesting data from {}: {}".format(url, err))
+            raise RequestError(f"Error requesting data from {url}: {err}")

--- a/setup.py
+++ b/setup.py
@@ -14,19 +14,19 @@ from shutil import rmtree
 from setuptools import find_packages, setup, Command  # type: ignore
 
 # Package meta-data.
-NAME = 'py17track'
-DESCRIPTION = 'A Simple Python API for 17track.net'
-URL = 'https://github.com/bachya/py17track'
-EMAIL = 'bachya1208@gmail.com'
-AUTHOR = 'Aaron Bach'
-REQUIRES_PYTHON = '>=3.5.3'
+NAME = "py17track"
+DESCRIPTION = "A Simple Python API for 17track.net"
+URL = "https://github.com/bachya/py17track"
+EMAIL = "bachya1208@gmail.com"
+AUTHOR = "Aaron Bach"
+REQUIRES_PYTHON = ">=3.6.0"
 VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [  # type: ignore
-    'aiohttp',
-    'async-timeout',
-    'attrs',
+    "aiohttp",
+    "async-timeout",
+    "attrs",
 ]
 
 # The rest you shouldn't have to touch too much :)
@@ -39,28 +39,28 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
-with io.open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
-    LONG_DESC = '\n' + f.read()
+with io.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
+    LONG_DESC = "\n" + f.read()
 
 # Load the package's __version__.py module as a dictionary.
 ABOUT = {}  # type: ignore
 if not VERSION:
-    with open(os.path.join(HERE, NAME, '__version__.py')) as f:
+    with open(os.path.join(HERE, NAME, "__version__.py")) as f:
         exec(f.read(), ABOUT)  # pylint: disable=exec-used
 else:
-    ABOUT['__version__'] = VERSION
+    ABOUT["__version__"] = VERSION
 
 
 class UploadCommand(Command):
     """Support setup.py upload."""
 
-    description = 'Build and publish the package.'
+    description = "Build and publish the package."
     user_options = []  # type: ignore
 
     @staticmethod
     def status(string):
-        """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(string))
+        """Print things in bold."""
+        print(f"\033[1m{string}\033[0m")
 
     def initialize_options(self):
         """Add options for initialization."""
@@ -73,21 +73,20 @@ class UploadCommand(Command):
     def run(self):
         """Run."""
         try:
-            self.status('Removing previous builds…')
-            rmtree(os.path.join(HERE, 'dist'))
+            self.status("Removing previous builds…")
+            rmtree(os.path.join(HERE, "dist"))
         except OSError:
             pass
 
-        self.status('Building Source and Wheel (universal) distribution…')
-        os.system('{0} setup.py sdist bdist_wheel --universal'.format(
-            sys.executable))
+        self.status("Building Source and Wheel (universal) distribution…")
+        os.system(f"{sys.executable} setup.py sdist bdist_wheel --universal")
 
-        self.status('Uploading the package to PyPi via Twine…')
-        os.system('twine upload dist/*')
+        self.status("Uploading the package to PyPi via Twine…")
+        os.system("twine upload dist/*")
 
-        self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(ABOUT['__version__']))
-        os.system('git push --tags')
+        self.status("Pushing git tags…")
+        os.system(f"git tag v{ABOUT['__version__']}")
+        os.system("git push --tags")
 
         sys.exit()
 
@@ -95,38 +94,34 @@ class UploadCommand(Command):
 # Where the magic happens:
 setup(
     name=NAME,
-    version=ABOUT['__version__'],
+    version=ABOUT["__version__"],
     description=DESCRIPTION,
     long_description=LONG_DESC,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author=AUTHOR,
     # author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=("tests",)),
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
-
     # entry_points={
     #     'console_scripts': ['mycli=mymodule:cli'],
     # },
     install_requires=REQUIRED,
     include_package_data=True,
-    license='MIT',
+    license="MIT",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy'
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     # $ setup.py publish support.
-    cmdclass={
-        'upload': UploadCommand,
-    },
+    cmdclass={"upload": UploadCommand},
 )


### PR DESCRIPTION
**Describe what the PR does:**

This PR drops runtime support for Python 3.5.3 and makes the minimum runtime version 3.6. One of a few benefits to follow: we now get to use f-strings.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
