### PR TITLE
Add Python 3.6-style variable type annotations

### DIFF
--- a/py17track/client.py
+++ b/py17track/client.py
@@ -1,4 +1,6 @@
 """Define a 17track.net client."""
+from typing import Optional
+
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
 
@@ -13,9 +15,9 @@ class Client:  # pylint: disable=too-few-public-methods
 
     def __init__(self, websession: ClientSession) -> None:
         """Initialize."""
-        self._websession = websession
+        self._websession: ClientSession = websession
 
-        self.profile = Profile(self._request)
+        self.profile: Profile = Profile(self._request)
 
         # This is disabled until a workaround can be found:
         # self.track = Track(self._request)
@@ -25,9 +27,9 @@ class Client:  # pylint: disable=too-few-public-methods
         method: str,
         url: str,
         *,
-        headers: dict = None,
-        params: dict = None,
-        json: dict = None,
+        headers: Optional[dict] = None,
+        params: Optional[dict] = None,
+        json: Optional[dict] = None,
     ) -> dict:
         """Make a request against the RainMachine device."""
         if not headers:
@@ -38,7 +40,7 @@ class Client:  # pylint: disable=too-few-public-methods
                 method, url, headers=headers, params=params, json=json
             ) as resp:
                 resp.raise_for_status()
-                data = await resp.json(content_type=None)
+                data: dict = await resp.json(content_type=None)
                 return data
         except ClientError as err:
             raise RequestError(f"Error requesting data from {url}: {err}")

--- a/py17track/package.py
+++ b/py17track/package.py
@@ -1,7 +1,9 @@
 """Define a simple structure for a package."""
+from typing import Dict, Optional
+
 import attr
 
-COUNTRY_MAP = {
+COUNTRY_MAP: Dict[int, str] = {
     0: "Unknown",
     102: "Afghanistan",
     103: "Albania",
@@ -233,7 +235,7 @@ COUNTRY_MAP = {
     9901: "Overseas Territory [NZ]",
 }
 
-PACKAGE_STATUS_MAP = {
+PACKAGE_STATUS_MAP: Dict[int, str] = {
     0: "Not Found",
     10: "In Transit",
     20: "Expired",
@@ -243,7 +245,7 @@ PACKAGE_STATUS_MAP = {
     50: "Returned",
 }
 
-PACKAGE_TYPE_MAP = {
+PACKAGE_TYPE_MAP: Dict[int, str] = {
     0: "Unknown",
     1: "Small Registered Package",
     2: "Registered Parcel",
@@ -255,17 +257,16 @@ PACKAGE_TYPE_MAP = {
 class Package:
     """Define a package object."""
 
-    tracking_number = attr.ib()
-    destination_country = attr.ib(default=0)
-    friendly_name = attr.ib(default=None)
-    info_text = attr.ib(default=None)
-    location = attr.ib(default="")
-    origin_country = attr.ib(default=0)
-    package_type = attr.ib(default=0)
-    status = attr.ib(default=0)
-    tracking_info_language = attr.ib(default="Unknown")
+    tracking_number: str = attr.ib()
+    destination_country: int = attr.ib(default=0)
+    friendly_name: Optional[str] = attr.ib(default=None)
+    info_text: Optional[str] = attr.ib(default=None)
+    location: str = attr.ib(default="")
+    origin_country: int = attr.ib(default=0)
+    package_type: int = attr.ib(default=0)
+    status: int = attr.ib(default=0)
+    tracking_info_language: str = attr.ib(default="Unknown")
 
-    # pylint: disable=attribute-defined-outside-init
     def __attrs_post_init__(self):
         """Do some post-init processing."""
         object.__setattr__(

--- a/py17track/track.py
+++ b/py17track/track.py
@@ -1,10 +1,10 @@
 """Define interaction with an individual package."""
-from typing import Callable, Coroutine
+from typing import Callable, Coroutine, List
 
 from .errors import InvalidTrackingNumberError
 from .package import Package
 
-API_URL_TRACK = "https://t.17track.net/restapi/track"
+API_URL_TRACK: str = "https://t.17track.net/restapi/track"
 
 
 class Track:  # pylint: disable=too-few-public-methods
@@ -12,26 +12,24 @@ class Track:  # pylint: disable=too-few-public-methods
 
     def __init__(self, request: Callable[..., Coroutine]) -> None:
         """Initialize."""
-        self._request = request
+        self._request: Callable[..., Coroutine] = request
 
     async def find(self, *tracking_numbers: str) -> list:
         """Get tracking info for one or more tracking numbers."""
-        data = {"data": [{"num": num} for num in tracking_numbers]}
-        tracking_resp = await self._request("post", API_URL_TRACK, json=data)
-
-        print(tracking_resp)
+        data: dict = {"data": [{"num": num} for num in tracking_numbers]}
+        tracking_resp: dict = await self._request("post", API_URL_TRACK, json=data)
 
         if not tracking_resp.get("dat"):
             raise InvalidTrackingNumberError("Invalid data")
 
-        packages = []
+        packages: List[Package] = []
         for info in tracking_resp["dat"]:
-            package_info = info.get("track", {})
+            package_info: dict = info.get("track", {})
 
             if not package_info:
                 continue
 
-            kwargs = {
+            kwargs: dict = {
                 "destination_country": package_info.get("c"),
                 "info_text": package_info.get("z0", {}).get("z"),
                 "location": package_info.get("z0", {}).get("c"),


### PR DESCRIPTION
**Describe what the PR does:**

Now that we can ensure a minimum of Python 3.6, we can use Python 3.6-style type annotations for variables.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
