### PR TITLE
Remove pre-commit repos from poetry dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,8 @@ repos:
     hooks:
       - id: mypy
         files: ^py17track/.+\.py$
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 5.0.2
+    hooks:
+      - id: pydocstyle
+        files: ^((py17track|tests)/.+)?[^/]+\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,22 @@
+[build-system]
+requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+
+[tool.isort]
+combine_as_imports = true
+default_section = "THIRDPARTY"
+force_grid_wrap = 0
+force_sort_within_sections = true
+forced_separate = "tests"
+include_trailing_comma = true
+indent = "    "
+known_first_party = "py17track,examples,tests"
+line_length = 88
+multi_line_output = 3
+not_skip = "__init__.py"
+sections = "FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
+use_parentheses = true
+
 [tool.poetry]
 name = "py17track"
 version = "2.2.6"
@@ -25,17 +44,7 @@ python = "^3.6.1"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^1.1.1"
-bandit = "^1.6.2"
-black = "^19.10b0"
-flake8 = "^3.7.9"
-mypy = "^0.761"
 pre-commit = "^2.0.1"
-pydocstyle = "^5.0.2"
-pylint = "^2.4.3"
 pytest = "^5.3.5"
 pytest-aiohttp = "^0.3.0"
 pytest-cov = "^2.8.1"
-
-[build-system]
-requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry>=0.12"]
-build-backend = "poetry.masonry.api"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,5 @@
 aiohttp==3.6.2
 aresponses==1.1.2
-pylint==2.4.4
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
 pytest==5.3.5

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 """Define tests for the client object."""
 import aiohttp
 import pytest
+
 from py17track import Client
 from py17track.errors import RequestError
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,6 +1,7 @@
 """Define tests for the client object."""
 import aiohttp
 import pytest
+
 from py17track import Client
 
 from .common import TEST_EMAIL, TEST_PASSWORD, load_fixture


### PR DESCRIPTION
**Describe what the PR does:**

Now that we use `pre-commit` hooks for lots of linting/etc. tasks, we don't need to install those same tools via `script/setup`. This PR makes the necessary changes.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
