### PR TITLE
Make aiohttp ClientSession optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ pip install py17track
 
 # Usage
 
-`py17track` starts within an
-[aiohttp](https://aiohttp.readthedocs.io/en/stable/) `ClientSession`:
-
 ```python
 import asyncio
 
@@ -43,15 +40,33 @@ from py17track import Client
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-      # YOUR CODE HERE
+    """Run!"""
+    client = Client()
+
+    # Login to 17track.net:
+    await client.profile.login('<EMAIL>', '<PASSWORD>')
+
+    # Get the account ID:
+    client.profile.account_id
+    # >>> 1234567890987654321
+
+    # Get a summary of the user's packages:
+    summary = await client.profile.summary()
+    # >>> {'In Transit': 3, 'Expired': 3, ... }
+
+    # Get all packages associated with a user's account:
+    packages = await client.profile.packages()
+    # >>> [py17track.package.Package(..), ...]
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())
 ```
 
-Create a client then get to it:
+By default, the library creates a new connection to 17track with each coroutine. If you
+are calling a large number of coroutines (or merely want to squeeze out every second of
+runtime savings possible), an
+[`aiohttp`](https://github.com/aio-libs/aiohttp) `ClientSession` can be used for connection
+pooling:
 
 ```python
 import asyncio
@@ -62,27 +77,14 @@ from py17track import Client
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-      client = Client(websession)
+    """Run!"""
+    async with ClientSession() as session:
+        client = Client(session=session)
 
-      # Login to 17track.net:
-      await client.profile.login('<EMAIL>', '<PASSWORD>')
-
-      # Get the account ID:
-      client.profile.account_id
-      # >>> 1234567890987654321
-
-      # Get a summary of the user's packages:
-      summary = await client.profile.summary()
-      # >>> {'In Transit': 3, 'Expired': 3, ... }
-
-      # Get all packages associated with a user's account:
-      packages = await client.profile.packages()
-      # >>> [py17track.package.Package(..), ...]
+        # ...
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())
 ```
 
 Each `Package` object has the following info:
@@ -103,7 +105,7 @@ Each `Package` object has the following info:
   or [initiate a discussion on one](https://github.com/bachya/py17track/issues/new).
 2. [Fork the repository](https://github.com/bachya/py17track/fork).
 3. (_optional, but highly recommended_) Create a virtual environment: `python3 -m venv .venv`
-4. (_optional, but highly recommended_) Enter the virtual environment: `source ./venv/bin/activate`
+4. (_optional, but highly recommended_) Enter the virtual environment: `source ./.venv/bin/activate`
 5. Install the dev environment: `script/setup`
 6. Code your new feature or bug fix.
 7. Write tests that cover your new functionality.

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -14,9 +14,9 @@ async def main() -> None:
     """Create the aiohttp session and run the example."""
     logging.basicConfig(level=logging.INFO)
 
-    async with ClientSession() as websession:
+    async with ClientSession() as session:
         try:
-            client = Client(websession)
+            client = Client(session=session)
 
             await client.profile.login("<EMAIL>", "<PASSWORD>")
             _LOGGER.info("Account ID: %s", client.profile.account_id)
@@ -30,4 +30,4 @@ async def main() -> None:
             print(err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,6 @@ python = "^3.6.1"
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"
 pre-commit = "^2.0.1"
-pytest = "^5.3.5"
+pytest = "^5.4.1"
 pytest-aiohttp = "^0.3.0"
 pytest-cov = "^2.8.1"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,4 @@ aiohttp==3.6.2
 aresponses==1.1.2
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
-pytest==5.3.5
+pytest==5.4.1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,6 +14,6 @@ async def test_bad_request(aresponses):
     )
 
     with pytest.raises(RequestError):
-        async with aiohttp.ClientSession() as websession:
-            client = Client(websession)
+        async with aiohttp.ClientSession() as session:
+            client = Client(session=session)
             await client._request("get", "https://random.domain/no/good")

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -19,8 +19,8 @@ async def test_login_failure(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(session=session)
         login_result = await client.profile.login(TEST_EMAIL, TEST_PASSWORD)
         assert login_result is False
 
@@ -37,10 +37,27 @@ async def test_login_success(aresponses):
         ),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(session=session)
         login_result = await client.profile.login(TEST_EMAIL, TEST_PASSWORD)
         assert login_result is True
+
+
+@pytest.mark.asyncio
+async def test_no_explicit_session(aresponses):
+    """Test not providing an explicit aiohttp ClientSession."""
+    aresponses.add(
+        "user.17track.net",
+        "/userapi/call",
+        "post",
+        aresponses.Response(
+            text=load_fixture("authentication_success_response.json"), status=200
+        ),
+    )
+
+    client = Client()
+    login_result = await client.profile.login(TEST_EMAIL, TEST_PASSWORD)
+    assert login_result is True
 
 
 @pytest.mark.asyncio
@@ -61,8 +78,8 @@ async def test_packages(aresponses):
         aresponses.Response(text=load_fixture("packages_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(session=session)
         await client.profile.login(TEST_EMAIL, TEST_PASSWORD)
         packages = await client.profile.packages()
         assert len(packages) == 2
@@ -86,8 +103,8 @@ async def test_summary(aresponses):
         aresponses.Response(text=load_fixture("summary_response.json"), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession)
+    async with aiohttp.ClientSession() as session:
+        client = Client(session=session)
         await client.profile.login(TEST_EMAIL, TEST_PASSWORD)
         summary = await client.profile.summary()
         assert summary["Delivered"] == 0


### PR DESCRIPTION
**Describe what the PR does:**

This PR makes the `aiohttp` `ClientSession` an optional parameter when creating an API object.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
