### PR TITLE
Upgrade aiohttp to a minimum of 3.7.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,10 +59,8 @@ repos:
     hooks:
       - id: pydocstyle
         files: ^((py17track|tests)/.+)?[^/]+\.py$
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.4
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.12
     hooks:
       - id: shellcheck
-        args:
-          - --format=json
         files: ^script/.+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-aiohttp = "^3.6.2"
+aiohttp = "^3.7.4"
 async-timeout = "^3.0.1"
 attrs = ">=19.3,<21.0"
 python = "^3.6.1"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-aiohttp==3.6.2
+aiohttp>=3.7.4
 aresponses==1.1.2
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1


### PR DESCRIPTION
**Describe what the PR does:**

This PR upgrades `aiohttp` to 3.7.4, which fixes https://github.com/advisories/GHSA-v6wp-4m6f-gcjg.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
