### PR TITLE
fix incorrect conversion of timezones

### DIFF
--- a/py17track/package.py
+++ b/py17track/package.py
@@ -283,16 +283,16 @@ class Package:
         object.__setattr__(self, "status", PACKAGE_STATUS_MAP[self.status])
 
         if self.timestamp is not None:
+            tz = timezone(self.tz)
             try:
-                tz = timezone(self.tz)
-                timestamp = datetime.strptime(
+                timestamp = tz.localize(datetime.strptime(
                     self.timestamp, "%Y-%m-%d %H:%M"
-                ).astimezone(tz)
+                ))
             except ValueError:
                 try:
-                    timestamp = datetime.strptime(
+                    timestamp = tz.localize(datetime.strptime(
                         self.timestamp, "%Y-%m-%d %H:%M:%S"
-                    ).astimezone(tz)
+                    ))
                 except ValueError:
                     timestamp = datetime(1970, 1, 1, tzinfo=UTC)
 

--- a/py17track/package.py
+++ b/py17track/package.py
@@ -285,14 +285,14 @@ class Package:
         if self.timestamp is not None:
             tz = timezone(self.tz)
             try:
-                timestamp = tz.localize(datetime.strptime(
-                    self.timestamp, "%Y-%m-%d %H:%M"
-                ))
+                timestamp = tz.localize(
+                    datetime.strptime(self.timestamp, "%Y-%m-%d %H:%M")
+                )
             except ValueError:
                 try:
-                    timestamp = tz.localize(datetime.strptime(
-                        self.timestamp, "%Y-%m-%d %H:%M:%S"
-                    ))
+                    timestamp = tz.localize(
+                        datetime.strptime(self.timestamp, "%Y-%m-%d %H:%M:%S")
+                    )
                 except ValueError:
                     timestamp = datetime(1970, 1, 1, tzinfo=UTC)
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -115,9 +115,9 @@ async def test_packages_default_timezone(aresponses):
         await client.profile.login(TEST_EMAIL, TEST_PASSWORD)
         packages = await client.profile.packages()
         assert len(packages) == 5
-        assert packages[0].timestamp == datetime(2018, 4, 23, 12, 2).astimezone(UTC)
-        assert packages[1].timestamp == datetime(2019, 2, 26, 1, 5, 34).astimezone(UTC)
-        assert packages[2].timestamp == datetime(1970, 1, 1, tzinfo=UTC)
+        assert packages[0].timestamp.isoformat() == "2018-04-23T12:02:00+00:00"
+        assert packages[1].timestamp.isoformat() == "2019-02-26T01:05:34+00:00"
+        assert packages[2].timestamp.isoformat() == "1970-01-01T00:00:00+00:00"
 
 
 @pytest.mark.asyncio
@@ -141,15 +141,11 @@ async def test_packages_user_defined_timezone(aresponses):
     async with aiohttp.ClientSession() as session:
         client = Client(session=session)
         await client.profile.login(TEST_EMAIL, TEST_PASSWORD)
-        packages = await client.profile.packages(tz="Europe/Berlin")
+        packages = await client.profile.packages(tz="Asia/Jakarta")
         assert len(packages) == 5
-        assert packages[0].timestamp == datetime(2018, 4, 23, 12, 2).astimezone(
-            timezone("Europe/Berlin")
-        )
-        assert packages[1].timestamp == datetime(2019, 2, 26, 1, 5, 34).astimezone(
-            timezone("Europe/Berlin")
-        )
-        assert packages[2].timestamp == datetime(1970, 1, 1, tzinfo=UTC)
+        assert packages[0].timestamp.isoformat() == "2018-04-23T05:02:00+00:00"
+        assert packages[1].timestamp.isoformat() == "2019-02-25T18:05:34+00:00"
+        assert packages[2].timestamp.isoformat() == "1970-01-01T00:00:00+00:00"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**
Fixes incorrect conversion of timezones. I had incorrectly used `.astimezone()` while I should have used `.localize()`. Tests did not show this as tests had same fallacy in assertions. Tests now check for incorrect time conversion by string-comparing the isoformat() output and also use a timezone that is far apart from UTC to let mistakes show up more cleary (before: Berlin is only +1h shift to UTC).

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
